### PR TITLE
Modify Release GHA to run on fork

### DIFF
--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -13,6 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Fail if QUAY_REGISTRY not set
+        run: |
+          if [[ -z "${{ vars.QUAY_REGISTRY }}" ]]; then
+            echo "QUAY_REGISTRY not set. Please set QUAY_REGISTRY in variable GitHub Actions variables."
+            exit 1
+          fi
+
       - name: Log into registry ghcr.io
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d    # v3.0.0
         with:
@@ -24,18 +31,18 @@ jobs:
       - name: Log into registry quay.io
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d    # v3.0.0
         with:
-          registry: quay.io/ansible/
+          registry: ${{ vars.QUAY_REGISTRY }}
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
 
 
       - name: Build and Store Image @ghcr
         run: |
-          IMG=ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.sha }} make docker-buildx
+          IMG=ghcr.io/${{ github.repository }}:${{ github.sha }} make docker-buildx
 
 
-      - name: Publish Image to quay.io/ansible/awx-operator:devel
+      - name: Publish Image to quay.io
         run: |
           docker buildx imagetools create \
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.sha }} \
-            --tag quay.io/ansible/${{ github.repository }}:devel
+            ghcr.io/${{ github.repository }}:${{ github.sha }} \
+            --tag ${{ vars.QUAY_REGISTRY }}/awx-operator:devel

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -8,20 +8,34 @@ on:
       tag_name:
         description: 'Name for the tag of the release.'
         required: true
+      quay_registry:
+        description: 'Quay registry to push to.'
+        default: 'quay.io/ansible'
+
+env:
+  QUAY_REGISTRY: ${{ vars.QUAY_REGISTRY }}
 
 jobs:
   promote:
     runs-on: ubuntu-latest
     steps:
-      - name: Set TAG_NAME for workflow_dispatch event
+      - name: Set GitHub Env vars for workflow_dispatch event
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           echo "TAG_NAME=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
+          echo "QUAY_REGISTRY=${{ github.event.inputs.quay_registry }}" >> $GITHUB_ENV
 
-      - name: Set TAG_NAME for release event
+      - name: Set GitHub Env vars if release event
         if: ${{ github.event_name == 'release' }}
         run: |
           echo "TAG_NAME=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+
+      - name: Fail if QUAY_REGISTRY not set
+        run: |
+          if [[ -z "${{ env.QUAY_REGISTRY }}" ]]; then
+            echo "QUAY_REGISTRY not set. Please set QUAY_REGISTRY in variable GitHub Actions variables."
+            exit 1
+          fi
 
       - uses: actions/checkout@v3
         with:
@@ -39,31 +53,31 @@ jobs:
       - name: Log into registry quay.io
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d    # v3.0.0
         with:
-          registry: quay.io/ansible/
+          registry: ${{ env.QUAY_REGISTRY }}
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
 
 
-      - name: Pull Stored Image and Publish to quay.io/${{ github.repository }}:${TAG_NAME}
+      - name: Pull Tagged Staged Image and Publish to quay.io
         run: |
           docker buildx imagetools create \
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${TAG_NAME} \
-            --tag quay.io/ansible/${{ github.repository }}:${TAG_NAME}
+            ghcr.io/${{ github.repository }}:${{ env.TAG_NAME }} \
+            --tag ${{ env.QUAY_REGISTRY }}/awx-operator:${{ env.TAG_NAME }}
 
 
-      - name: Pull Stored Image and Publish to quay.io/${{ github.repository }}:latest
+      - name: Pull Staged Image and Publish to quay.io/${{ github.repository }}:latest
         run: |
           docker buildx imagetools create \
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${TAG_NAME} \
-            --tag quay.io/ansible/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ env.TAG_NAME }} \
+            --tag ${{ env.QUAY_REGISTRY }}/awx-operator:latest
 
 
       - name: Release Helm chart
         run: |
           ansible-playbook ansible/helm-release.yml -v \
-            -e operator_image=quay.io/${{ github.repository }} \
+            -e operator_image=${{ env.QUAY_REGISTRY }}/awx-operator \
             -e chart_owner=${{ github.repository_owner }} \
-            -e tag=${TAG_NAME} \
+            -e tag=${{ env.TAG_NAME }} \
             -e gh_token=${{ secrets.GITHUB_TOKEN }} \
             -e gh_user=${{ github.actor }} \
             -e repo_type=https

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -37,12 +37,6 @@ jobs:
 
           exit 0
 
-      - name: Checkout awx
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ github.repository_owner }}/awx
-          path: awx
-
       - name: Checkout awx-operator
         uses: actions/checkout@v3
         with:
@@ -61,10 +55,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Stage awx-operator
+        working-directory: awx-operator
         run: |
           BUILD_ARGS="--build-arg DEFAULT_AWX_VERSION=${{ github.event.inputs.default_awx_version }} \
               --build-arg OPERATOR_VERSION=${{ github.event.inputs.version }}" \
-          IMG=ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.event.inputs.version }} \
+          IMG=ghcr.io/${{ github.repository }}:${{ github.event.inputs.version }} \
           make docker-buildx
 
       - name: Run test deployment
@@ -78,10 +73,12 @@ jobs:
         env:
           AWX_TEST_VERSION: ${{ github.event.inputs.default_awx_version }}
 
-      - name: Create draft release
-        working-directory: awx
-        run: |
-          ansible-playbook tools/ansible/stage.yml \
-            -e version=${{ github.event.inputs.version }} \
-            -e repo=${{ github.repository_owner }}/awx-operator \
-            -e github_token=${{ secrets.GITHUB_TOKEN }}
+      - name: Create Draft Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          release_name: Release ${{ github.event.inputs.version }}
+          draft: true


### PR DESCRIPTION
##### SUMMARY

@TheRealHaoLiu and I tested out this workflow on our fork today and got it working with the changes in this PR.

Mainly, we modified how it runs so that we could test it on a fork and push the images to our personal quay registry so as not to affect the official awx-operator images while testing.  

There were also a few variable refs that needed to be changed for the workflow to work.  Notably:
* `ghcr.io/${{ github.repository_owner }}/${{ github.repository }}` evaluates to `ghcr.io/ansible/ansible/awx-operator`, which failed.


I also changed how it creates the draft release so that it uses the github action for it rather than custom logic to git the GitHub API.